### PR TITLE
Normalize `created` timestamp to seconds in response from proxy handlers

### DIFF
--- a/src/openai/chat/completions/NonStreamingChatProxyHandler.ts
+++ b/src/openai/chat/completions/NonStreamingChatProxyHandler.ts
@@ -11,7 +11,7 @@ export async function nonStreamingChatProxyHandler(req: OpenAI.Chat.ChatCompleti
   const resp: OpenAI.Chat.ChatCompletion = {
     id: "chatcmpl-abc123",
     object: "chat.completion",
-    created: Date.now(),
+    created: Math.floor(Date.now()/1000),
     model: req.model,
     choices: [
       {

--- a/src/openai/chat/completions/StreamingChatProxyHandler.ts
+++ b/src/openai/chat/completions/StreamingChatProxyHandler.ts
@@ -12,7 +12,7 @@ export async function* streamingChatProxyHandler(req: OpenAI.Chat.ChatCompletion
     return {
       id: "chatcmpl-abc123",
       object: "chat.completion.chunk",
-      created: Date.now(),
+      created: Math.floor(Date.now()/1000),
       model: req.model,
       choices: [
         {


### PR DESCRIPTION
This commit adjusts the `created` field in both `NonStreamingChatProxyHandler` and `StreamingChatProxyHandler` to use a timestamp in seconds rather than milliseconds. It applies `Math.floor(Date.now()/1000)` to ensure the `created` timestamp is consistent with OpenAI's response, enhancing compatibility, especially to response handlers in strongly typed language like rust