### PR TITLE
修复bug：请求错误时的报错信息可能泄露apikey

### DIFF
--- a/src/gemini-api-client/gemini-api-client.ts
+++ b/src/gemini-api-client/gemini-api-client.ts
@@ -51,7 +51,7 @@ async function makeRequest(url: RequestUrl, body: string, requestOptions?: Reque
       throw new Error(`[${response.status} ${response.statusText}] ${message}`)
     }
   } catch (e) {
-    const err = new GoogleGenerativeAIError(`Error fetching from ${url.toURL()} -> ${e.message}`)
+    const err = new GoogleGenerativeAIError(`Error fetching from google -> ${e.message}`)
     err.stack = e.stack
     throw err
   }


### PR DESCRIPTION
在请求错误（如超出频次限制）时返回给用户的响应中，会显示例如
[GoogleGenerativeAI Error]: Error fetching from https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=xxxx -> [429 Too Many Requests] Resource has been exhausted (e.g. check quota). 导致apikey泄露