### PR TITLE
Add vercel deploy support

### DIFF
--- a/api/handler.mjs
+++ b/api/handler.mjs
@@ -1,0 +1,29 @@
+import worker from "../dist/main_cloudflare-workers.mjs";
+
+export default worker.fetch;
+
+export const config = {
+  runtime: "edge", 
+  // Available languages and regions for Google AI Studio and Gemini API
+  // https://ai.google.dev/available_regions#available_regions
+  // https://vercel.com/docs/concepts/edge-network/regions
+  regions: [
+    //"arn1",
+    "bom1",
+    //"cdg1",
+    "cle1",
+    "cpt1",
+    //"dub1",
+    //"fra1",
+    "gru1",
+    //"hkg1",
+    "hnd1",
+    "iad1",
+    "icn1",
+    "kix1",
+    "pdx1",
+    "sfo1",
+    "sin1",
+    "syd1",
+  ],
+};

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,17 @@ Copy [`main_cloudflare-workers.mjs`](./dist/main_cloudflare-workers.mjs) to
 
 Copy [`main_deno.mjs`](./dist/main_deno.mjs) to `deno deploy`
 
+### [Vercel](https://vercel.com)
+
+> build command `npm run build:cf_worker`
+
+ [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/zuisong/gemini-openai-proxy&repository-name=gemini-openai-proxy)
+
+- Alternatively can be deployed with [cli](https://vercel.com/docs/cli):
+  `vercel deploy`
+- Serve locally: `vercel dev`
+- Vercel _Functions_ [limitations](https://vercel.com/docs/functions/limitations) (with _Edge_ runtime)
+
 ## Run On Local
 
 ### deno

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "api/handler"
+        }
+    ]
+}


### PR DESCRIPTION
This pull requests adds necessary files for using Vercel as a deployment platform and updates Readme file
accordingly. Vercel uses the same file as a CloudFlare worker does.

Why is this needed?
Cloudflare workers and (probably) Deno could not be setup to work only in gemini supported regions, but vercel does.

Also, great project, it really helped me to use gemini without VPNs
